### PR TITLE
Make the JS example match the HTML example (tutorial 1#images)

### DIFF
--- a/posts/_posts/2012-6-25-fabric-intro-part-1.html
+++ b/posts/_posts/2012-6-25-fabric-intro-part-1.html
@@ -360,7 +360,7 @@ staticCanvas.add(
 
 <pre>
 var canvas = new fabric.Canvas('c');
-var imgElement = document.getElementById('my-img');
+var imgElement = document.getElementById('my-image');
 var imgInstance = new fabric.Image(imgElement, {
   left: 100,
   top: 100,


### PR DESCRIPTION
The id the JS example is referencing doesn’t exist. This updates the JS
to match the id in the HTML example.