### PR TITLE
Update Event Selection Page

### DIFF
--- a/posts/demos/_posts/2011-9-1-events.html
+++ b/posts/demos/_posts/2011-9-1-events.html
@@ -75,7 +75,6 @@ title: Event inspector
   }
 
   observe('object:modified');
-  observe('object:selected');
   addSeparator();
 
   observe('object:moving');
@@ -87,6 +86,7 @@ title: Event inspector
   observe('before:selection:cleared');
   observe('selection:cleared');
   observe('selection:created');
+  observe('selection:updated');
   addSeparator();
 
   observe('mouse:up');


### PR DESCRIPTION
I know there's probably a larger rewrite on the way, but I went ahead and updated the events page to reflect new changes in 2.0, mainly removing the deprecated object:selected, and adding selection:updated to the list of watched entities. This is a super high frequented page for me and others, and hopefully will prevent some confusion in the interim.